### PR TITLE
reads env KUBECONFIG before defaulting to ${HOME}/.kube/config

### DIFF
--- a/kubetop.go
+++ b/kubetop.go
@@ -45,7 +45,11 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	configFilepath := filepath.Join(usr.HomeDir, ".kube", "config")
+
+	configFilepath := os.Getenv("KUBECONFIG")
+    if len(configFilepath) == 0 {
+        configFilepath = filepath.Join(usr.HomeDir, ".kube", "config")
+    }
 
 	fmt.Printf("Using %s\n", configFilepath)
 	config, err := clientcmd.BuildConfigFromFlags("", configFilepath)


### PR DESCRIPTION
Just threw in a quick test for the KUBECONFIG environment variable, which if empty (not set or empty string), defaults to ${HOME}/.kube/config